### PR TITLE
Integrate Github actions

### DIFF
--- a/.github/workflows/github-actions-pull-requests.yml
+++ b/.github/workflows/github-actions-pull-requests.yml
@@ -1,0 +1,23 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: npm ci
+      - run: npm run hardhat:compile
+      - run: npm run hardhat:test


### PR DESCRIPTION
Github actions are free for public repositories so I figure we might as well turn them on and get some free CI validation of our project.

