### PR TITLE
Gas optimization and more tests

### DIFF
--- a/test/tiramisu-savings-club.ts
+++ b/test/tiramisu-savings-club.ts
@@ -137,6 +137,13 @@ describe("Tiramisu savings club", () => {
             group = await getGroup(1);
             expect(group.members.length).to.equal(0);
           });
+
+          it("should revert deposit when caller is not part of the group", async function () {
+            await contract.createGroup(addresses.slice(0,2), names.slice(0,2), 0);            
+            await expect(
+                contract.connect(accounts[2]).deposit({ value: 100 })
+            ).to.be.revertedWith("Caller not member of a group");
+        });                    
     });
 
     describe("withdraw", function () {
@@ -188,6 +195,15 @@ describe("Tiramisu savings club", () => {
             const group1 = await getGroup(1);
             expect(group1.nextPayee).to.equal(1);
         });
+
+        it("should revert withdraw when caller is not part of the group", async function () {
+            await contract.createGroup(addresses.slice(0,2), names.slice(0,2), 0);
+            await contract.deposit({ value: 10000 });
+            
+            await expect(
+                contract.connect(accounts[2]).deposit({ value: 100 })
+            ).to.be.revertedWith("Caller not member of a group");
+        });        
     });
 
     describe("dissolve", function () {


### PR DESCRIPTION
Changes made:

Additional deposit and withdraw tests - Deposit and Withdraw should revert if caller not part of the group

In createGroup function -
1) New group will now be created and pushed to the storage array once we iterate though all the members and validate that none of them belong to any previous group. Creating a new group and adding it to the storage variable will waste gas if one of the member already belong to a group.

2) We increment counter, for the next group, at the start of the function and before the member validation is done. If member validation fails, we don't need to increment counter. Also, counter.sol uses storage variable, which will cost unnecessary gas.

In withdraw function
1) If there is a failure to send the amount to the caller, we are manually reverting the state in if(!sent) block. Manual is not required as the require(_sent) will take care of reverting the state in case of failure.

TODO - Add unit test to test the failure condition of (bool _sent, ) = payable(msg.sender).call{value: 1}("");
