### PR TITLE
Add ENS reverse lookup support

### DIFF
--- a/src/services/ethereumService.js
+++ b/src/services/ethereumService.js
@@ -29,9 +29,24 @@ export function isConnectedToSupportedNetwork(){
 }
 
 //attemptWalletConnect() should be successfully called first before this function is called
+
+/**
+ * Get human readable wallet address
+ * - WARNING: attemptWalletConnect() should be successfully called first before this function is called
+ * - WARNING: This does not guarantee an Ethereum address. This might return an ENS name
+ * @returns {string} ENS name from reverse lookup OR Ethereum address
+ */
 export async function getCurrentWalletAddress(){
     if(!signer) return null;
-    return await signer.getAddress();    
+    
+    const address = await signer.getAddress();
+    let ensName = null;
+    if (provider) {
+        ensName = await provider.lookupAddress(address);
+    }
+    const result = ensName === null ? address : ensName;
+    debugger;
+    return result;
 }
 
 if(window.ethereum){

--- a/src/services/ethereumService.js
+++ b/src/services/ethereumService.js
@@ -44,9 +44,7 @@ export async function getCurrentWalletAddress(){
     if (provider) {
         ensName = await provider.lookupAddress(address);
     }
-    const result = ensName === null ? address : ensName;
-    debugger;
-    return result;
+    return ensName === null ? address : ensName;
 }
 
 if(window.ethereum){


### PR DESCRIPTION
If you enter an address in the Create Group component that has a reverse lookup mapped to an ENS name, we will resolve it and show that instead of the Ethereum address

https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution

This is a safe change to make, because the only caller of this function is the setState() function, which plumbs it down as a prop only to the create group component, which only uses it to display the ethereum address to the user.
So all this does is make the UI look a little nicer when interacting with a reverse lookup enabled ENS name